### PR TITLE
Fix mapCoverage option deprecation warning and enable coverage collection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   moduleNameMapper: require('./aliases.config').jest,
   snapshotSerializers: ['jest-serializer-vue'],
-  mapCoverage: true,
+  collectCoverage: true,
   coverageDirectory: '<rootDir>/tests/unit/coverage',
   collectCoverageFrom: [
     'src/**/*.{js,vue}',


### PR DESCRIPTION
Reference:

- [Jest Changelog: Deprecate mapCoverage option](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2240)
- [Commit: Removing the mapCoverage condition on...](https://github.com/facebook/jest/commit/966aab60faa1b0a8cfdd51b95bcca780c68001d7)
- [Jest Doc: collectCoverage configuration](https://facebook.github.io/jest/docs/en/configuration.html#collectcoverage-boolean)