### PR TITLE
Fix lint warning in login component

### DIFF
--- a/src/router/views/login.vue
+++ b/src/router/views/login.vue
@@ -58,8 +58,8 @@ export default {
         type="password"
       />
       <BaseButton
-        type="submit"
         :disabled="tryingToLogIn"
+        type="submit"
       >
         <BaseIcon
           v-if="tryingToLogIn"


### PR DESCRIPTION
On first start, the vue eslint was warning about the order of attributes. This addresses that