### PR TITLE
async/await support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,6 +9,13 @@ module.exports = {
       },
     ],
   ],
+  plugins: [
+    // async/await support (regenerator-runtime).
+    [
+      '@babel/transform-runtime',
+      { helpers: false, polyfill: false, regenerator: true },
+    ],
+  ],
   env: {
     test: {
       presets: [

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -10,7 +10,10 @@ module.exports = {
     ],
   ],
   plugins: [
-    // async/await support (regenerator-runtime).
+    // Support async/await
+    // NOTE: Using async/await at least once will increase
+    // the size of your app bundle by almost 10KB gzipped.
+    // https://babeljs.io/docs/plugins/transform-runtime/
     [
       '@babel/transform-runtime',
       { helpers: false, polyfill: false, regenerator: true },


### PR DESCRIPTION
@chrisvfritz to support ES2017 async/await, this appears to be the required config – the polyfill.io service does not provide this feature; or: vue-cli generated apps get this via [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) but it's hence removed by passing the `useBuiltIns: false` option.

Is this something you're okay with being added to the project?