### PR TITLE
Enable F12 navigation in vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -18,6 +18,8 @@
     // Test `.unit.js` files on save with Jest
     "Orta.vscode-jest",
     // Lint markdown in README files
-    "DavidAnson.vscode-markdownlint"
+    "DavidAnson.vscode-markdownlint",
+    // Navigate to vue file using F12
+    "dariofuzinato.vue-peek"
   ]
 }

--- a/aliases.config.js
+++ b/aliases.config.js
@@ -1,20 +1,30 @@
 const path = require('path')
+const jsconfig = require('./jsconfig.json')
 
 function resolveSrc(_path) {
   return path.join(__dirname, _path)
 }
 
-const aliases = {
-  '@src': 'src',
-  '@router': 'src/router',
-  '@views': 'src/router/views',
-  '@layouts': 'src/router/layouts',
-  '@components': 'src/components',
-  '@assets': 'src/assets',
-  '@utils': 'src/utils',
-  '@state': 'src/state',
-  '@design': 'src/design/index.scss',
+/**
+ * In jsconfig.json, the aliases are stored in arrays.
+ * convert aliases into the expected format: {[alias:string]:string}
+ *
+ * @example `{"@src/*": ["src/*"]} will be converted to {"@src": "src"}
+ * @param {[alias:string]: Array<string>} aliasesArrays
+ * @returns Converted aliases
+ */
+function resolveJsConfig(aliasesArrays) {
+  const simplifiedAliases = {}
+  const slashStarRE = /\/\*$/g
+  for (let alias in aliasesArrays) {
+    const aliasTmp = alias.replace(slashStarRE, '')
+    const pathTmp = aliasesArrays[alias][0].replace(slashStarRE, '')
+    simplifiedAliases[aliasTmp] = pathTmp
+  }
+  return simplifiedAliases
 }
+
+const aliases = resolveJsConfig(jsconfig.compilerOptions.paths)
 
 module.exports = {
   webpack: {},

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["src/*"],
+      "@router/*": ["src/router/*"],
+      "@views/*": ["src/router/views/*"],
+      "@layouts/*": ["src/router/layouts/*"],
+      "@components/*": ["src/components/*"],
+      "@assets/*": ["src/assets/*"],
+      "@utils/*": ["src/utils/*"],
+      "@state/*": ["src/state/*"],
+      "@design": ["src/design/index.scss"]
+    }
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -12,5 +12,6 @@
       "@state/*": ["src/state/*"],
       "@design": ["src/design/index.scss"]
     }
-  }
+  },
+  "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
As specified in [this doc](https://code.visualstudio.com/docs/languages/jsconfig#_using-webpack-aliases), in order for vscode to understand webpack aliases, it needs a little help.
In order to keep the code as DRY (don't repeat yourself) as possible,
I **moved** the aliases definition in the static `jsconfig.json` file.

![nvopt](https://user-images.githubusercontent.com/5592465/43680333-c5f98ca2-97fd-11e8-974c-c6ec29cf4701.gif)
