### PR TITLE
Just a couple of small little things

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -13,7 +13,7 @@ export default {
 </script>
 
 <template>
-  <div id="app">
+  <div class="app">
     <!--
     Even when routes use the same component, treat them
     as distinct and create the component again.
@@ -47,7 +47,7 @@ body {
   background: $color-body-bg;
 }
 
-#app {
+.app {
   @extend %typography-small;
 }
 

--- a/src/router/layouts/main.vue
+++ b/src/router/layouts/main.vue
@@ -20,5 +20,6 @@ export default {
   min-width: $size-content-width-min;
   max-width: $size-content-width-max;
   margin: 0 auto;
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
id="app" is already declared in public index.html... It is then re-declared in main.vue. So, it is declared twice. Anyway, the fact that is was declared twice didn't affect Vue's ability to mount the app as the id="app" in app.vue was being replaced appropriately when built. It just hurts my soul a little bit.

Maybe there is a reason for the the duplicate declaration? If so, I'd like to know your thinking... just so I "get it". 

Also, the logo wasn't centered... hurt my soul even more. :)

