### PR TITLE
Fix vue-test-utils documentation links in setup.js

### DIFF
--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -8,7 +8,7 @@ import axios from 'axios'
 // Utility functions
 // ===
 
-// https://vue-test-utils.vuejs.org/en/
+// https://vue-test-utils.vuejs.org/
 import vueTestUtils from '@vue/test-utils'
 // https://lodash.com/
 import _ from 'lodash'
@@ -79,10 +79,10 @@ Object.defineProperty(window, 'localStorage', {
 // Global helpers
 // ===
 
-// https://vue-test-utils.vuejs.org/en/api/mount.html
+// https://vue-test-utils.vuejs.org/api/#mount
 global.mount = vueTestUtils.mount
 
-// https://vue-test-utils.vuejs.org/en/api/shallowMount.html
+// https://vue-test-utils.vuejs.org/api/#shallowmount
 global.shallowMount = vueTestUtils.shallowMount
 
 // A special version of `shallowMount` for view components
@@ -105,13 +105,13 @@ global.shallowMountView = (Component, options = {}) => {
 global.createComponentMocks = ({ store, router, style, mocks, stubs }) => {
   // Use a local version of Vue, to avoid polluting the global
   // Vue and thereby affecting other tests.
-  // https://vue-test-utils.vuejs.org/en/api/createLocalVue.html
+  // https://vue-test-utils.vuejs.org/api/#createlocalvue
   const localVue = vueTestUtils.createLocalVue()
   const returnOptions = { localVue }
 
-  // https://vue-test-utils.vuejs.org/en/api/options.html#stubs
+  // https://vue-test-utils.vuejs.org/api/options.html#stubs
   returnOptions.stubs = stubs || {}
-  // https://vue-test-utils.vuejs.org/en/api/options.html#mocks
+  // https://vue-test-utils.vuejs.org/api/options.html#mocks
   returnOptions.mocks = mocks || {}
 
   // Converts a `store` option shaped like:


### PR DESCRIPTION
These links keep on 404ing for me, so I fixed them. :)