### PR TITLE
fix: fix wrong unit test for nav-bar-routes

### DIFF
--- a/src/components/nav-bar-routes.unit.js
+++ b/src/components/nav-bar-routes.unit.js
@@ -3,15 +3,13 @@ import NavBarRoutes from './nav-bar-routes'
 const mountRoutes = options => {
   return mount(
     {
-      components: { NavBarRoutes },
       render(h) {
         return (
           <ul>
-            <NavBarRoutes routes={this.routes} />
+            <NavBarRoutes {...{ props: options.propsData }} />
           </ul>
         )
       },
-      props: ['routes'],
     },
     {
       stubs: {

--- a/src/components/nav-bar-routes.unit.js
+++ b/src/components/nav-bar-routes.unit.js
@@ -7,17 +7,11 @@ const mountRoutes = options => {
       render(h) {
         return (
           <ul>
-            <NavBarRoutes
-              routes={[
-                {
-                  name: 'aaa',
-                  title: 'bbb',
-                },
-              ]}
-            />
+            <NavBarRoutes routes={this.routes} />
           </ul>
         )
       },
+      props: ['routes'],
     },
     {
       stubs: {


### PR DESCRIPTION
This fixes a wrongly written unit test for the `nav-bar-routes` component.

The test was not assigning the provided prop on each test.