### PR TITLE
Fix broken comment link

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -15,7 +15,7 @@ module.exports = {
     sourceMap: true,
   },
   // Configure Webpack's dev server.
-  // https://github.com/vuejs/vue-cli/blob/dev/docs/cli-service.md
+  // https://cli.vuejs.org/guide/cli-service.html
   devServer: {
     ...(process.env.API_BASE_URL
       ? // Proxy API endpoints to the production base URL.


### PR DESCRIPTION
The link to the cli service documentation no longer works, it should be replaced with a link to the new documentation.