### PR TITLE
Don't convert global components to PascalCase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     'vue/component-name-in-template-casing': [
       'error',
       'PascalCase',
+      'registeredComponentsOnly': true,
       {
         ignores: [
           'component',


### PR DESCRIPTION
Some global components, such as ones found in Vuetify and AWS Amplify are kebab cased and the PascalCase linting rule was frustratingly converting them. 

For example `<v-app>` was being converted to `<VApp>` for Vuetify.

This adds the relatively new 'registeredComponentsOnly' option to the template, [which was recently added](https://github.com/vuejs/eslint-plugin-vue/pull/714).