### PR TITLE
Update Vetur config in settings.json 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,7 @@
     { "language": "vue-html", "autoFix": true },
     { "language": "html", "autoFix": true }
   ],
+  "vetur.format.enable": false,
   "vetur.completion.useScaffoldSnippets": false,
   "prettier.disableLanguages": [],
 
@@ -52,7 +53,6 @@
   "emmet.includeLanguages": {
     "vue-html": "html"
   },
-  "vetur.format.defaultFormatter.html": "none",
   "vetur.completion.tagCasing": "initial",
 
   // ===
@@ -64,8 +64,6 @@
   "javascript.format.enable": false,
   "json.format.enable": false,
   "vetur.validation.script": false,
-  "vetur.format.defaultFormatter.js": "none",
-  "vetur.format.defaultFormatter.ts": "none",
 
   // ===
   // CSS
@@ -75,11 +73,6 @@
   "css.validate": false,
   "scss.validate": false,
   "vetur.validation.style": false,
-  "vetur.format.defaultFormatter.css": "none",
-  "vetur.format.defaultFormatter.postcss": "none",
-  "vetur.format.defaultFormatter.scss": "none",
-  "vetur.format.defaultFormatter.less": "none",
-  "vetur.format.defaultFormatter.stylus": "none",
 
   // ===
   // MARKDOWN


### PR DESCRIPTION
Formatting is not working automatically when saving a `.vue` file. (Vetur 0.18.1)

Running Format Document manually, VSCode will ask user to pick the formatter

<img width="223" alt="shot" src="https://user-images.githubusercontent.com/5123601/56016487-f746c580-5d2e-11e9-8ec2-598eb1003548.png">

It seems like VSCode won't use prettier as the default formatter.

Vetur support `vetur.format.enable` since 0.17.1.

Changing it to false will solve this issue.

Setting below is also helpful, VSCode March 2019 (version 1.33) required
```
  "[vue]": {
    "editor.defaultFormatter": "esbenp.prettier-vscode"
  }
```