### PR TITLE
Fixed matchedUser typo

### DIFF
--- a/src/state/modules/users.js
+++ b/src/state/modules/users.js
@@ -23,7 +23,7 @@ export const actions = {
     // 2. Check if we've already fetched and cached the user.
     const matchedUser = state.cached.find((user) => user.username === username)
     if (matchedUser) {
-      return Promise.resolve(currentUser)
+      return Promise.resolve(matchedUser)
     }
 
     // 3. Fetch the user from the API and cache it in case


### PR DESCRIPTION
Instead of returning the cached user, subsequent requests always returned currentUser.