### PR TITLE
Fix problem with Jest and .vue files for lint-stage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   globalTeardown: '<rootDir>/tests/unit/global-teardown',
   setupFilesAfterEnv: ['<rootDir>/tests/unit/matchers'],
   testMatch: ['**/(*.)unit.js'],
-  moduleFileExtensions: ['js', 'json'],
+  moduleFileExtensions: ['js', 'json', 'vue'],
   transform: {
     '^.+\\.vue$': 'vue-jest',
     '^.+\\.js$': 'babel-jest',


### PR DESCRIPTION
**The problem:**
https://github.com/chrisvfritz/vue-enterprise-boilerplate/issues/179

In the configuration jest.config.js the moduleFileExtensions field does not contain .vue extensions.
Because of this, when you run yarn `test:unit:file path/to/component.vue` Jest did not find the test file associated with the component. So same, under commit only .Vue component without changes associated with it the test file, Jest did not run the test

```
module.exports = {
  ...
  moduleFileExtensions: ['js', 'json'],
}
```

**The solution:**
Add .vue extension to moduleFileExtensions

```
module.exports = {
  ...
  moduleFileExtensions: ['js', 'json', 'vue'],
}
```
