### PR TITLE
Add explanation about pre-commit hook

### DIFF
--- a/docs/linting.md
+++ b/docs/linting.md
@@ -34,7 +34,7 @@ See `package.json` to update.
 
 ### Pre-commit
 
-Staged files are automatically linted and tested before each commit. See `lint-staged.config.js` to update. [Yorkie](https://www.npmjs.com/package/yorkie) is used under the hood to detect the pre-commit hook.
+Staged files are automatically linted and tested before each commit. See `lint-staged.config.js` to update. [Yorkie](https://github.com/yyx990803/yorkie) is used by `@vue/cli-plugin-eslint` to install the pre-commit hook.
 
 ### Editor
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -34,7 +34,7 @@ See `package.json` to update.
 
 ### Pre-commit
 
-Staged files are automatically linted and tested before each commit. See `lint-staged.config.js` to update.
+Staged files are automatically linted and tested before each commit. See `lint-staged.config.js` to update. [Yorkie](https://www.npmjs.com/package/yorkie) is used under the hood to detect the pre-commit hook.
 
 ### Editor
 


### PR DESCRIPTION
Hi @chrisvfritz 
I thought it could be useful to add a small note about how the pre-commit hook works, even though Yorkie is not a direct dependency of this project (it's a dependency of `@vue/cli-plugin-eslint`).
