### PR TITLE
Remove `scoped` from App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ import HelloWorld from './components/HelloWorld.vue'
   <RouterView />
 </template>
 
-<style scoped>
+<style>
 header {
   line-height: 1.5;
   max-height: 100vh;


### PR DESCRIPTION
The thinking behind this change is that App.vue is hosting global styles that definitionally _should_ leak. The use of `scoped` prevents this from happening, so it feels awkward/counter-intuitive for "global" styles to be scoped to the parent component (only) and not applicable to it's children. If the goal is to write styles that are specific to the nav or the header only, perhaps those should live in individual components or maybe PageLayout component that's designed to be added to each page/screen?